### PR TITLE
fix broken link to install.sh in docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -32,7 +32,7 @@ For the lucky Linux / MacOS users, you can just run this command in your termina
 $ curl -Ls http://restx.io/install.sh | sh
 {% endhighlight %}
 
-[View source](https://github.com/restx/restx/blob/gh-pages/install.sh)
+[View source](https://github.com/restx/restx.github.io/blob/master/install.sh)
 
 Then you should be able to run `restx`:
 {% highlight console %}


### PR DESCRIPTION
the old one:

https://github.com/restx/restx/blob/gh-pages/install.sh

leads to 404
