### PR TITLE
attempt to fix the menu on a 1366x768 screen

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -660,7 +660,6 @@ article.docs {
 
 #menu {
   position: absolute;
-  width: 810px;
   z-index: 10;
   bottom: -40px;
   right: 0;


### PR DESCRIPTION
The menu of the restx website looks broken on my laptop:

![before](https://cloud.githubusercontent.com/assets/626069/3202509/77563fd4-ed91-11e3-8397-32b269bde87f.png)

Not sure if my fix breaks something else, but for my resolution it looks better:

![after](https://cloud.githubusercontent.com/assets/626069/3202513/7c4e6ee4-ed91-11e3-9ef6-3ec4d16bb390.png)
