### PR TITLE
Remove unnecessary width declaration

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -660,7 +660,6 @@ article.docs {
 
 #menu {
   position: absolute;
-  width: 810px;
   z-index: 10;
   bottom: -40px;
   right: 0;


### PR DESCRIPTION
On my machine (Linux, Chrome) the menu items wraps "Download" under "News" which looks quite ugly. Removing the width fixes the issue for me.
