### PR TITLE
Change in RestxRoute signature

### DIFF
--- a/docs/ref-core.md
+++ b/docs/ref-core.md
@@ -123,7 +123,7 @@ public class FactoryDumpRoute extends StdRoute {
     private final Factory factory;
     @Inject
     public FactoryDumpRoute(Factory factory) {
-        super("FactoryRoute", new StdRouteMatcher("GET", "/@/factory"));
+        super("FactoryRoute", new StdRestxRequestMatcher("GET", "/@/factory"));
         this.factory = factory;
     }
     @Override


### PR DESCRIPTION
Was:

``` java
public void handle(RestxRouteMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx)
```

and is now

``` java
public void handle(RestxRequestMatch match, RestxRequest req, RestxResponse resp, RestxContext ctx)
```
